### PR TITLE
Changed return type for PHP 8.1 compatibility

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -40,7 +40,7 @@ class Message implements \JsonSerializable
         return $this->key;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }


### PR DESCRIPTION
Since PHP 8.1 the JsonSerialize::jsonSerialize method now have this signature:

public function jsonSerialize(): mixed;

and produces error if return type is not set.